### PR TITLE
🐛 Fix Devcontainer Dependency Install & Docker Config Cleanup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
     5173
   ],
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "yarn install",
+  "postCreateCommand": "yarn install",
 
   // Configure tool-specific properties.
   "customizations": {

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,3 @@
-# Self docker
-docker/Dockerfile
-docker-compose.yaml
-docker-compose.override.yaml
-
 # Logs
 logs
 *.log

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,8 +1,6 @@
 services:
   app:
     build:
-      context: .
-      dockerfile: docker/Dockerfile
       target: base
     environment:
       NODE_ENV: development


### PR DESCRIPTION
# 🐛 Fix Devcontainer Dependency Install & Docker Config Cleanup

This PR ensures dependencies are installed automatically when creating the devcontainer and streamlines Docker-related configs.

---

## ✅ Changes

- [x] `fix`: 🐛 Enable `postCreateCommand` in `.devcontainer/devcontainer.json`  
  - Runs `yarn install` after container creation  
  - Guarantees `node_modules` exists even when workspace is mounted  

- [x] `chore`: 🧹 Clean up `.dockerignore`  
  - Removed redundant self-docker references:  
    - `docker/Dockerfile`  
    - `docker-compose.yaml`  
    - `docker-compose.override.yaml`  
  - Prevents potential context/build conflicts  

- [x] `chore`: 🧹 Simplify `compose.override.yaml`  
  - Removed unnecessary `context` and `dockerfile` under `app.build`  
  - Kept only `target: base` for clarity and maintainability  

---

## 💡 Why

- Fixes restart loop (`vite` missing → exit code 127) when container mounts workspace without `node_modules`.  
- Reduces clutter and potential conflicts in Docker/devcontainer setup.  
- Improves reliability and developer experience.  