### PR TITLE
💡 Sync i18n initialization and TS/Vite config tuning

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,10 +1,17 @@
 import "@shared/styles/globals.scss";
 import "@shared/styles/tailwind.css";
-import {type ReactElement, StrictMode} from "react";
+import {i18nReady} from '@i18n/i18n.js'
+import {type Dispatch, type ReactElement, type SetStateAction, StrictMode, useEffect, useState} from "react";
 import AppRoutes from "./AppRoutes.tsx";
-import '@i18n/i18n';
 
-export default function App(): ReactElement {
+export default function App(): ReactElement | null {
+    const [ready, setReady]: [boolean, Dispatch<SetStateAction<boolean>>] = useState<boolean>(false);
+    useEffect((): void => {
+        i18nReady.then((): void => setReady(true));
+    }, []);
+
+    if (!ready) return null;
+
     return (
         <main className='h-lvh w-full'>
             <StrictMode>

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -40,16 +40,20 @@ const initialLng: string | undefined = (
     }
 )();
 
-await i18n.use(initReactI18next).init({
-    resources,
-    lng: initialLng,
-    fallbackLng: 'en',
-    ns: namespaces.length ? namespaces : ['messages'],
-    defaultNS: 'messages',
-    keySeparator: ' ',
-    interpolation: {escapeValue: false},
-    debug: false, // Use true for i18n debugging
-});
+export const i18nReady: Promise<void> = (
+    async (): Promise<void> => {
+        await i18n.use(initReactI18next).init({
+            resources,
+            lng: initialLng,
+            fallbackLng: 'en',
+            ns: namespaces.length ? namespaces : ['messages'],
+            defaultNS: 'messages',
+            keySeparator: ' ',
+            interpolation: {escapeValue: false},
+            debug: false,
+        });
+    }
+)();
 
 declare global {
     interface Window {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,7 +27,9 @@
     "jsx": "react-jsx",
 
     /* Linting / Strictness */
+    "declaration": true,
     "erasableSyntaxOnly": false,
+    "emitDeclarationOnly": true,
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
@@ -36,7 +38,6 @@
     "strict": true
   },
   "include": [
-    "src",
-    "src/types"
+    "src"
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,4 +27,12 @@ export default defineConfig({
             '@shared': path.resolve(__dirname, 'src/shared'),
         },
     },
+
+    esbuild: {
+        target: 'es2022', // ou 'esnext'
+    },
+
+    build: {
+        target: 'es2022', // garante compatibilidade com top-level await
+    }
 });


### PR DESCRIPTION
# 💡 Async i18n initialization and TypeScript/Vite config tuning

This PR refactors the app’s i18n initialization to ensure React renders only after localization is fully ready, and enhances TypeScript and Vite configuration for improved build consistency and ES2022 compatibility.

---

## Internationalization
- [x] `refactor`: 💡 make i18n initialization asynchronous via exported `i18nReady` promise
  - Move `await i18n.init(...)` into an async IIFE and export it as `i18nReady` from `src/i18n/i18n.ts`.
  - Preserve existing `resources`, `fallbackLng`, and interpolation config.
  - Remove direct import of `@i18n/i18n` in `App.tsx`, now dynamically awaited.

## Application Bootstrapping
- [x] `feat`: 🎸 delay React render until `i18n` is ready
  - Update `App.tsx` to import `i18nReady` and use `useState` + `useEffect` to wait before rendering.
  - Return `null` (suspense-like behavior) until translation setup completes.
  - Keep `StrictMode` and main layout unchanged.

---

## Tooling & Config
- [x] `chore`: 🤖 update TypeScript and Vite build targets
  - Add `declaration: true` and `emitDeclarationOnly: true` to `tsconfig.app.json` for type emission.
  - Set Vite’s `esbuild.target` and `build.target` to `es2022` for compatibility with top-level await.
  - Maintain alias configuration for `@app`, `@shared`, and `@i18n`.
